### PR TITLE
Make it possible to use a header or a query parameter

### DIFF
--- a/DependencyInjection/Security/SwitchUserStatelessFactory.php
+++ b/DependencyInjection/Security/SwitchUserStatelessFactory.php
@@ -42,8 +42,9 @@ class SwitchUserStatelessFactory implements SecurityFactoryInterface
             )
             ->replaceArgument(1, new Reference($userProvider))
             ->replaceArgument(3, $id)
-            ->replaceArgument(6, $config['parameter'])
-            ->replaceArgument(7, $config['role'])
+            ->replaceArgument(6, $config['query_parameter'])
+            ->replaceArgument(7, $config['header'])
+            ->replaceArgument(8, $config['role'])
         ;
 
         return [$providerId, $listenerId, $defaultEntryPoint];
@@ -72,7 +73,8 @@ class SwitchUserStatelessFactory implements SecurityFactoryInterface
     {
         /* @var ArrayNodeDefinition $node */
         $node->children()
-            ->scalarNode('parameter')->defaultValue('X-Switch-User')->end()
+            ->scalarNode('query_parameter')->defaultValue(null)->end()
+            ->scalarNode('header')->defaultValue('X-Switch-User')->end()
             ->scalarNode('role')->defaultValue('ROLE_ALLOWED_TO_SWITCH')->end()
         ;
     }

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ You can configure the parameter used in HTTP request and role of user who switch
 # app/config/config.yml
 
 switch_user_stateless:
-    parameter: 'X-Switch-User'
+    header: 'X-Switch-User'
+    query_parameter: '_switch_user'
     role: 'ROLE_ALLOWED_TO_SWITCH'
 ```
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -19,7 +19,8 @@
             <argument /> <!--  Provider Key -->
             <argument type="service" id="security.access.decision_manager" />
             <argument type="service" id="logger" on-invalid="null" />
-            <argument>X-Switch-User</argument>
+            <argument /> <!-- query_parameter -->
+            <argument>X-Switch-User</argument> <!-- header -->
             <argument>ROLE_ALLOWED_TO_SWITCH</argument>
             <argument type="service" id="event_dispatcher" on-invalid="null"/>
         </service>

--- a/Tests/DependencyInjection/Security/SwitchUserStatelessFactoryTest.php
+++ b/Tests/DependencyInjection/Security/SwitchUserStatelessFactoryTest.php
@@ -16,7 +16,7 @@ class SwitchUserStatelessFactoryTest extends \PHPUnit_Framework_TestCase
         $builder = new ContainerBuilder();
 
         $factory = new SwitchUserStatelessFactory();
-        $config = ['parameter' => 'myParameter', 'role' => 'myRole'];
+        $config = ['header' => 'myHeader', 'query_parameter' => 'myParameter', 'role' => 'myRole'];
 
         list($providerId, $listenerId, $defaultEntryPoint) = $factory
             ->create($builder, 'myId', $config, 'myUserProvider', 'myEntryPoint');
@@ -46,12 +46,13 @@ class SwitchUserStatelessFactoryTest extends \PHPUnit_Framework_TestCase
 
         $nodeMock->children()->willReturn($nodeBuilderMock->reveal())->shouldBeCalledTimes(1);
 
-        $nodeBuilderMock->scalarNode(Argument::type('string'))->willReturn($scalarNodeMock->reveal())->shouldBeCalledTimes(2);
+        $nodeBuilderMock->scalarNode(Argument::type('string'))->willReturn($scalarNodeMock->reveal())->shouldBeCalledTimes(3);
 
         $scalarNodeMock->defaultValue('X-Switch-User')->willReturn($nodeMock->reveal())->shouldBeCalledTimes(1);
+        $scalarNodeMock->defaultValue(null)->willReturn($nodeMock->reveal())->shouldBeCalledTimes(1);
         $scalarNodeMock->defaultValue('ROLE_ALLOWED_TO_SWITCH')->willReturn($nodeMock->reveal())->shouldBeCalledTimes(1);
 
-        $nodeMock->end()->willReturn($nodeBuilderMock->reveal())->shouldBeCalledTimes(2);
+        $nodeMock->end()->willReturn($nodeBuilderMock->reveal())->shouldBeCalledTimes(3);
 
         $factory = new SwitchUserStatelessFactory();
         $factory->addConfiguration($nodeMock->reveal());

--- a/Tests/Security/Firewall/SwitchUserStatelessListenerTest.php
+++ b/Tests/Security/Firewall/SwitchUserStatelessListenerTest.php
@@ -62,6 +62,7 @@ class SwitchUserStatelessListenerTest extends \PHPUnit_Framework_TestCase
             $accessDecisionManager,
             $logger,
             'myParameter',
+            'myHeader',
             'myRole',
             $eventDispatcher
         );
@@ -91,6 +92,7 @@ class SwitchUserStatelessListenerTest extends \PHPUnit_Framework_TestCase
         return [
             $this->getHandleDataWrongParameter(),
             $this->getHandleDataNotConnected(),
+            $this->getHandleQueryDataNotConnected(),
             $this->getHandleDataNotAllowedToSwitch(),
             $this->getHandleDataUnknownUser(),
             $this->getHandleDataAllowedToSwitch(),
@@ -116,7 +118,20 @@ class SwitchUserStatelessListenerTest extends \PHPUnit_Framework_TestCase
     private function getHandleDataNotConnected()
     {
         $request = new Request();
-        $request->headers->set('myParameter', 'newUser');
+        $request->headers->set('myHeader', 'newUser');
+        $tokenStorageMock = $this->getTokenStorageMock();
+        $tokenStorageMock->getToken()->shouldBeCalled();
+
+        return [$request, $tokenStorageMock->reveal(), new TokenNotFoundException()];
+    }
+
+    /**
+     * @return array
+     */
+    private function getHandleQueryDataNotConnected()
+    {
+        $request = new Request();
+        $request->query->set('myParameter', 'newUser');
         $tokenStorageMock = $this->getTokenStorageMock();
         $tokenStorageMock->getToken()->shouldBeCalled();
 
@@ -129,7 +144,7 @@ class SwitchUserStatelessListenerTest extends \PHPUnit_Framework_TestCase
     private function getHandleDataNotAllowedToSwitch()
     {
         $request = new Request();
-        $request->headers->set('myParameter', 'newUser');
+        $request->headers->set('myHeader', 'newUser');
 
         $tokenMock = $this->getTokenMock();
         $tokenMock->getUsername()->willReturn('adminUsername')->shouldBeCalled();
@@ -153,7 +168,7 @@ class SwitchUserStatelessListenerTest extends \PHPUnit_Framework_TestCase
     private function getHandleDataUnknownUser()
     {
         $request = new Request();
-        $request->headers->set('myParameter', 'newUser');
+        $request->headers->set('myHeader', 'newUser');
 
         $tokenMock = $this->getTokenMock();
         $tokenMock->getUsername()->willReturn('adminUsername')->shouldBeCalled();
@@ -181,7 +196,7 @@ class SwitchUserStatelessListenerTest extends \PHPUnit_Framework_TestCase
     private function getHandleDataAllowedToSwitch()
     {
         $request = new Request();
-        $request->headers->set('myParameter', 'newUser');
+        $request->headers->set('myHeader', 'newUser');
 
         $previousRole = new Role('MY_ROLE');
         $userMock = $this->getUserMock();


### PR DESCRIPTION
Previously the SwitchUserStatelessBundle would only consider request
headers. This commit adds the ability to use a query parameter as well,
so the feature can be used in contexts where it's not possible to add
custom headers to the query.

To do so we introcude the new 'query_parameter' setting, which is empty
by default to keep the old behaviour. The old 'parameter' parameter is
renamed to 'header' to avoid confusion. This naming is somewhat
consistent with the naming used in LexikJwtAuthenticationBundle.

If the header or query parameter settings are set to an empty value,
then the related source is not considered.